### PR TITLE
DEV: Simply removal of default loading spinner

### DIFF
--- a/javascripts/discourse/api-initializers/setup-loading-indicator.js
+++ b/javascripts/discourse/api-initializers/setup-loading-indicator.js
@@ -7,8 +7,6 @@ import DiscourseURL from "discourse/lib/url";
 const PLUGIN_ID = "discourse-loading-slider";
 
 export default apiInitializer("0.8", (api) => {
-  // eslint-disable-next-line no-undef
-  delete Ember.TEMPLATES["loading"];
   const { isAppWebview } = api.container.lookup("capabilities:main");
 
   api.modifyClass("route:application", {
@@ -21,13 +19,7 @@ export default apiInitializer("0.8", (api) => {
       transition.promise.finally(() => {
         this.loadingIndicator.end();
       });
-
-      let superLoading = this._super();
-      if (superLoading !== null) {
-        return superLoading;
-      }
-
-      return true;
+      return false;
     },
   });
 


### PR DESCRIPTION
Returning a falsey from the `loading()` action in the application route prevents the event from bubbling any further and triggering the 'loading substate' in the Ember router. If the loading substate is never hit, then the default loading template will never be displayed. This approach means we don't have to hack with the `Ember.TEMPLATES` object (which we are hoping to move away from in Discourse core).

In reality, we were (accidentally) already doing this. Calling `this._super()` in `loading()` on the Application route always returns an value of `undefined`. That passed our `!== null` check, and thereby returned a falsey value. The `return true` would never be hit.